### PR TITLE
Make string craftable with jute fiber

### DIFF
--- a/src/main/resources/data/immersiveengineering/recipes/crafting/string.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crafting/string.json
@@ -3,13 +3,13 @@
   "category": "misc",
   "ingredients": [
     {
-      "item": "immersiveengineering:hemp_fiber"
+      "tag": "forge:fiber_hemp"
     },
     {
-      "item": "immersiveengineering:hemp_fiber"
+      "tag": "forge:fiber_hemp"
     },
     {
-      "item": "immersiveengineering:hemp_fiber"
+      "tag": "forge:fiber_hemp"
     }
   ],
   "result": {


### PR DESCRIPTION
Change string recipe to use forge:fiber_hemp instead of immersiveengineering:hemp_fiber so it can be crafted using jute fiber. The manual seems to imply jute is supposed to be the replacement for hemp for the purposes of the crossover, right?